### PR TITLE
1499 - checks if a rmqvhost is not already in the database at creation/update

### DIFF
--- a/scripts/create_user.py
+++ b/scripts/create_user.py
@@ -1,6 +1,9 @@
 import sys
+
 from brain.models.sqlobjects import User
 from brain.helpers.sql import session_transaction
+
+from lib.irma.common.exceptions import IrmaDatabaseResultNotFound
 
 
 if len(sys.argv) not in (4, 5):
@@ -13,11 +16,21 @@ if len(sys.argv) not in (4, 5):
           "".format(sys.argv[0]))
     sys.exit(1)
 
+name = sys.argv[1]
+rmqvhost = sys.argv[2]
+ftpuser = sys.argv[3]
 # quota is in number of files (0 means disabled)
 quota = int(sys.argv[4]) if len(sys.argv) == 5 else 0
 with session_transaction() as session:
-    user = User(name=sys.argv[1],
-                rmqvhost=sys.argv[2],
-                ftpuser=sys.argv[3],
-                quota=quota)
-    user.save(session)
+    try:
+        user = User.get_by_rmqvhost(rmqvhost, session)
+        print("rmqvhost {0} is already assigned to user {1}. "
+              "Updating with new parameters.".format(user.name, user.rmqvhost))
+        user = user.load(user.id, session)
+        user.name = name
+        user.ftpuser = ftpuser
+        user.quota = quota
+        user.update(['name', 'ftpuser', 'quota'], session)
+    except IrmaDatabaseResultNotFound:
+        user = User(name=name, rmqvhost=rmqvhost, ftpuser=ftpuser, quota=quota)
+        user.save(session)


### PR DESCRIPTION
The following behaviour is implemented:

- if a rmqvhost already in the database, update the entry.
- if a rmqvhost is not in the database, creates an entry.