### PR TITLE
sftp has been updated to allow by key authentication. New option has …

### DIFF
--- a/brain/controllers/ftpctrl.py
+++ b/brain/controllers/ftpctrl.py
@@ -23,6 +23,7 @@ def flush_dir(ftpuser, scanid):
     with IrmaFTP(conf_ftp.host,
                  conf_ftp.port,
                  conf_ftp.auth,
+                 conf_ftp.key_path,
                  conf_ftp.username,
                  conf_ftp.password,
                  dst_user=ftpuser) as ftp:

--- a/brain/controllers/ftpctrl.py
+++ b/brain/controllers/ftpctrl.py
@@ -22,6 +22,7 @@ def flush_dir(ftpuser, scanid):
     conf_ftp = config.brain_config['ftp_brain']
     with IrmaFTP(conf_ftp.host,
                  conf_ftp.port,
+                 conf_ftp.auth,
                  conf_ftp.username,
                  conf_ftp.password,
                  dst_user=ftpuser) as ftp:

--- a/config/brain.ini
+++ b/config/brain.ini
@@ -36,6 +36,7 @@ tables_prefix = irma
 
 [ftp_brain]
 host = 127.0.0.1
+auth = password
 username = probe
 password = probe
 

--- a/config/parser.py
+++ b/config/parser.py
@@ -76,6 +76,7 @@ template_brain_config = {
     'ftp_brain': [
         ('host', TemplatedConfiguration.string, None),
         ('port', TemplatedConfiguration.integer, 22),
+        ('auth', TemplatedConfiguration.string, "password"),
         ('username', TemplatedConfiguration.string, None),
         ('password', TemplatedConfiguration.string, None),
         ],

--- a/config/parser.py
+++ b/config/parser.py
@@ -22,6 +22,8 @@ from logging import BASIC_FORMAT, Formatter
 from logging.handlers import SysLogHandler
 from celery.log import redirect_stdouts_to_logger
 from celery.signals import after_setup_task_logger, after_setup_logger
+
+from lib.irma.common.exceptions import IrmaConfigurationError
 from lib.irma.configuration.ini import TemplatedConfiguration
 from lib.irma.ftp.sftp import IrmaSFTP
 from lib.irma.ftp.ftps import IrmaFTPS
@@ -77,6 +79,7 @@ template_brain_config = {
         ('host', TemplatedConfiguration.string, None),
         ('port', TemplatedConfiguration.integer, 22),
         ('auth', TemplatedConfiguration.string, "password"),
+        ('key_path', TemplatedConfiguration.string, ""),
         ('username', TemplatedConfiguration.string, None),
         ('password', TemplatedConfiguration.string, None),
         ],
@@ -309,6 +312,11 @@ def get_lock_path():
 def get_ftp_class():
     protocol = brain_config.ftp.protocol
     if protocol == "sftp":
+        key_path = brain_config.ftp_brain.key_path
+        auth = brain_config.ftp_brain.auth
+        if auth == "key" and not os.path.isfile(key_path):
+            raise IrmaConfigurationError("You are using SFTP authentication by key but the path of the private key "
+                                         "does not exist:['" + key_path + "']")
         return IrmaSFTP
     elif protocol == "ftps":
         return IrmaFTPS


### PR DESCRIPTION
### New option is BRAIN.INI configuration file:

[ftp_brain]
host = 
**auth = password || key**
username = probe
password =
### To enable key authentication in the brain:
- create a RSA key for user **irma** (~/.ssh/id_rsa) in brain
- add the RSA public key in authorized keys of user **probe** of the brain server (~/.ssh/authorized_keys)

**Note**: irma user and probe user must be created with HOME
